### PR TITLE
add check for litecli

### DIFF
--- a/files/sqliteinout/Makefile
+++ b/files/sqliteinout/Makefile
@@ -21,13 +21,18 @@ step:	$(HOME)/.sqliterc
 shell:	$(HOME)/.sqliterc
 	@rm -f database.db
 	@for x in $(shell ls .*.sql); do sqlite3 database.db < $$x > /dev/null; done
+ifeq (, $(shell which litecli))
 	sqlite3 database.db
+else
+	litecli database.db
+endif
 
 $(HOME)/.sqliterc:	lib/.sqliterc
 	cp lib/.sqliterc $(HOME)/
 
 setup:
 	sudo apt install -y sqlite3 make python3
+	python3 -m pip install litecli
 
 clean:
 	rm -f test_detail.xml database.db outputs/*.actual


### PR DESCRIPTION
Hi Russ,

This small PR adds support for `litecli` as the default when dropping into a sqlite shell via `make shell`. 
`litecli` is part of a greater collection of command line database clients with "modern" enhancements like syntax highlighting, autocompletion, saved queries, etc. You can read more about them here: https://www.dbcli.com/

### Motivation
Remembering the particular vernacular of column names can prove challenging. Making the experience friendly and truly interactive for students allows them to focus more on writing the queries.

### Changes
- The `shell` target checks if `litecli` is installed according to output from `which` - if it is installed, it will be used instead of sqlite3. 
- The `setup` target includes the necessary code to install it via pip.

As per make documentation for [conditionals](https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html), the `ifeq`, `else`, and `endif` directives should *not* be tabbed in
to prevent them from being interpreted as shell commands. 