### PR TITLE
Update dependencies

### DIFF
--- a/containers/python/Dockerfile
+++ b/containers/python/Dockerfile
@@ -16,4 +16,12 @@ RUN apk add --no-cache \
     py3-setuptools \
     py3-six \
     diffutils
-RUN pip3 install --break-system-packages unittest-xml-reporting cisc108
+RUN pip3 install --break-system-packages \
+    unittest-xml-reporting \
+    cisc108 \
+    fastapi \
+    pydantic \
+    httpx \
+    sqlmodel \
+    python-decouple \
+    psycopg2-binary

--- a/files/typescriptunittest/tsconfig.json
+++ b/files/typescriptunittest/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "commonjs",
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
We need to have a couple more libraries for our python problems, and ES2021 is the compiler we need for our typescript problems. It's a better one to have overall anyway.