### PR TITLE
cli: Allow configuring default download directory

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func CommandConfig(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		mustLoadConfig(cmd)
+		if Config.Root != "" {
+			fmt.Printf("root: %s\n", Config.Root)
+		} else {
+			fmt.Println("root: (default: ~)")
+		}
+		return
+	}
+
+	if len(args) != 2 || args[0] != "root" {
+		cmd.Help()
+		os.Exit(1)
+	}
+
+	path, err := filepath.Abs(args[1])
+	if err != nil {
+		log.Fatalf("invalid path: %v", err)
+	}
+
+	mustLoadConfig(cmd)
+	Config.Root = path
+	mustWriteConfig()
+	fmt.Printf("root directory set to: %s\n", Config.Root)
+}

--- a/cli/get.go
+++ b/cli/get.go
@@ -17,11 +17,16 @@ import (
 func CommandGet(cmd *cobra.Command, args []string) {
 	mustLoadConfig(cmd)
 
-	rootDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatalf("unable to find home directory: %v", err)
+	rootDir := Config.Root
+	prettyRoot := Config.Root
+	if rootDir == "" {
+		var err error
+		rootDir, err = os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("unable to find home directory: %v", err)
+		}
+		prettyRoot = "~"
 	}
-	prettyRoot := "~"
 
 	if len(args) == 0 {
 		cmd.Help()

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,6 +29,7 @@ const (
 var Config struct {
 	Host      string `json:"host"`
 	Cookie    string `json:"cookie"`
+	Root      string `json:"root,omitempty"`
 	apiReport bool
 	apiDump   bool
 }
@@ -77,6 +78,16 @@ func main() {
 		Run: CommandLogin,
 	}
 	cmdGrind.AddCommand(cmdLogin)
+
+	cmdConfig := &cobra.Command{
+		Use:   "config [root <path>]",
+		Short: "show or set configuration options",
+		Long: fmt.Sprintf("View or modify configuration settings.\n\n"+
+			"   Example: '%s config'\n"+
+			"   Example: '%s config root /Users/me/csci'\n", os.Args[0], os.Args[0]),
+		Run: CommandConfig,
+	}
+	cmdGrind.AddCommand(cmdConfig)
 
 	cmdList := &cobra.Command{
 		Use:   "list",
@@ -206,6 +217,15 @@ func CommandLogin(cmd *cobra.Command, args []string) {
 
 		log.Fatalf("Usage: %s login <hostname> <sessionkey>", os.Args[0])
 	}
+
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		configFile := filepath.Join(home, perUserDotFile)
+		if raw, err := os.ReadFile(configFile); err == nil {
+			json.Unmarshal(raw, &Config)
+		}
+	}
+
 	hostname, key := args[0], args[1]
 	Config.Host = hostname
 


### PR DESCRIPTION
Adds a `grind config` command to set a custom root directory for assignments, which grind get will now use by default. Also ensures config settings are preserved across logins.