### PR TITLE
Fix sqlite problem type

### DIFF
--- a/containers/sqlite/Dockerfile
+++ b/containers/sqlite/Dockerfile
@@ -1,9 +1,31 @@
 FROM alpine:latest
 
-RUN mkdir /home/student && chmod 777 /home/student
-WORKDIR /home/student
+ENV HOME=/home/student
+
+RUN mkdir -p $HOME && chmod 777 $HOME
+WORKDIR $HOME
+
 RUN apk add --no-cache \
-    make \
+    build-base \
+    wget \
     python3
-RUN apk add --no-cache \
-    sqlite
+
+WORKDIR /tmp
+
+# "Pin" sqlite to 3.53 until alpine includes it in their packages.
+# A _lot_ of changes were made in 3.53, including a bunch of changes
+# to formatting, which when you have tests that rely on specifically
+# formatted output, is a problem. Students will need to make sure to
+# have 3.53 installed locally as well if they want to be able to pass
+# `make` as well as `grind grade`.
+RUN wget https://www.sqlite.org/2026/sqlite-autoconf-3530000.tar.gz \
+ && tar xzf sqlite-autoconf-3530000.tar.gz \
+ && cd sqlite-autoconf-3530000 \
+ && ./configure --prefix=/usr/local \
+ && make -j$(nproc) \
+ && make install \
+ && rm -rf /tmp/*
+
+ENV PATH="/usr/local/bin:$PATH"
+
+WORKDIR $HOME

--- a/files/sqliteinout/Makefile
+++ b/files/sqliteinout/Makefile
@@ -1,16 +1,16 @@
 .SUFFIXES:
 .SUFFIXES: .db .sql .actual .expected .xml
 
-STEPPER_DELAY=0.05
-STEPPER_WARMUPDELAY=0.5
-STEPPER_POSTCRASHLINES=15
-STEPPER_WRONGLINES=10
 STEPPER_SUFFIX=sql
 STEPPER_INDIR=.
 STEPPER_OUTDIR=outputs
 STEPPER_CMD=sqlite3 database.db
-export STEPPER_DELAY STEPPER_WARMUPDELAY STEPPER_POSTCRASHLINES STEPPER_WRONGLINES
+STEPPER_DIR=inputs
+STEPPER_TIMEOUT=30.0
+STEPPER_POSTERRORLINES=15
+
 export STEPPER_SUFFIX STEPPER_INDIR STEPPER_OUTDIR STEPPER_CMD
+export STEPPER_DIR STEPPER_POSTERRORLINES STEPPER_TIMEOUT
 
 all:	step
 
@@ -19,10 +19,11 @@ grade:	$(HOME)/.sqliterc
 	@for x in $(shell ls .*.sql); do sqlite3 database.db < $$x > /dev/null; done
 	@python3 lib/grader
 
-step:	$(HOME)/.sqliterc
+step:	$(HOME)/.sqliterc transcripts
 	@rm -f database.db
 	@for x in $(shell ls .*.sql); do sqlite3 database.db < $$x > /dev/null; done
 	@python3 lib/stepper
+	@rm -rf $$STEPPER_DIR
 
 shell:	$(HOME)/.sqliterc
 	@rm -f database.db
@@ -34,6 +35,13 @@ $(HOME)/.sqliterc:	lib/.sqliterc
 
 setup:
 	sudo apt install -y icdiff make python3 sqlite3
+
+transcripts:
+	@mkdir -p $$STEPPER_DIR
+	@for f in outputs/*.expected; do \
+		base=$$(basename $$f .expected); \
+		{ printf '< .read %s.sql\n' $$base; sed 's/^/> /' $$f; } > inputs/$$base.transcript; \
+	done
 
 clean:
 	rm -f test_detail.xml database.db outputs/*.actual


### PR DESCRIPTION
SQLite updated a ton of stuff in 3.53, including changing some formatting. This messed up some of our tests because some people are on this latest version, while others are on older versions. With these changes, we just need to make sure our students are running at least 3.53, then they can pass the tests locally with `make` as well as with `grind grade`.

This also includes a new rule in the makefile which allows us to have an `outputs/` directory with the expected output, then solution files in the root of the problem. It'll handle creating the transcript files so the test can run smoothly.

## NOTE

This does mean that expected outputs will probably need to be updated for a number of problems. It's easy to fix, just regenerate the expected output for any problem that fails when running `grind create`.